### PR TITLE
Added the option to change the jumper ssh port

### DIFF
--- a/crate/ssh_jumper/src/ssh_jumper.rs
+++ b/crate/ssh_jumper/src/ssh_jumper.rs
@@ -35,7 +35,7 @@ impl SshJumper {
             local_socket,
             target_socket,
         } = ssh_tunnel_params;
-        let ssh_session = Self::open_ssh_session(jump_host, jump_host_auth_params).await?;
+        let ssh_session = Self::open_ssh_session_at_port(jump_host, jump_host_auth_params).await?;
         let local_socket_addr =
             Self::open_direct_channel(&ssh_session, *local_socket, target_socket).await?;
 
@@ -52,6 +52,19 @@ impl SshJumper {
         jump_host_addr: &HostAddress<'_>,
         jump_host_auth_params: &JumpHostAuthParams<'_>,
     ) -> Result<SshSession, Error> {
+        SshJumper::open_ssh_session_at_port(&HostSocketParams{ address: jump_host_addr.clone(), port: 22 }, jump_host_auth_params).await
+    }
+
+    /// Opens an SSH session to a host with given port.
+    ///
+    /// # Parameters
+    ///
+    /// * `jump_host_addr`: Address of the jump host.
+    /// * `jump_host_auth_params`: SSH authentication parameters.
+    pub async fn open_ssh_session_at_port(
+        jump_host_addr: &HostSocketParams<'_>,
+        jump_host_auth_params: &JumpHostAuthParams<'_>,
+    ) -> Result<SshSession, Error> {
         // See https://github.com/bk-rs/async-ssh2-lite/blob/1b88c9c/demos/smol/src/remote_port_forwarding.rs
         // but we use `channel_direct_tcpip` for local forwarding
 
@@ -63,14 +76,14 @@ impl SshJumper {
             .map_err(Error::PrivateKeyPlainPath)?;
         let jump_host_private_key_passphrase = jump_host_auth_params.passphrase.as_deref();
 
-        let jump_host_ip = match jump_host_addr {
-            HostAddress::IpAddr(ip_addr) => *ip_addr,
+        let jump_host_ip = match jump_host_addr.clone().address {
+            HostAddress::IpAddr(ip_addr) => ip_addr,
             HostAddress::HostName(jump_host_addr) => Self::resolve_ip(&jump_host_addr).await?,
         };
-        let stream = Async::<TcpStream>::connect(SocketAddr::from((jump_host_ip, 22)))
+        let stream = Async::<TcpStream>::connect(SocketAddr::from((jump_host_ip, jump_host_addr.port)))
             .await
             .map_err(|io_error| Error::JumpHostConnectFail {
-                jump_host_addr: jump_host_addr.into_static(),
+                jump_host_addr: jump_host_addr.address.into_static(),
                 io_error,
             })?;
 
@@ -99,6 +112,7 @@ impl SshJumper {
 
         Ok(SshSession(session))
     }
+
 
     /// Returns the local address to a new tunnel to the given target host.
     ///

--- a/crate/ssh_jumper_model/src/ssh_tunnel_params.rs
+++ b/crate/ssh_jumper_model/src/ssh_tunnel_params.rs
@@ -9,8 +9,8 @@ const LOCAL_OS_CHOSEN_PORT: u16 = 0;
 /// Parameters to create the SSH tunnel.
 #[derive(Clone, Debug)]
 pub struct SshTunnelParams<'tunnel> {
-    /// Jump host address.
-    pub jump_host: HostAddress<'tunnel>,
+    /// Jump host address and port.
+    pub jump_host: HostSocketParams<'tunnel>,
     /// SSH auth params for the jump host.
     pub jump_host_auth_params: JumpHostAuthParams<'tunnel>,
     /// Local socket to forward to the target host.
@@ -39,9 +39,13 @@ impl<'tunnel> SshTunnelParams<'tunnel> {
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             LOCAL_OS_CHOSEN_PORT,
         );
+        let jump_host_params: HostSocketParams = HostSocketParams{
+            address: jump_host,
+            port: 22,
+        };
 
         SshTunnelParams {
-            jump_host,
+            jump_host: jump_host_params,
             jump_host_auth_params,
             local_socket,
             target_socket,
@@ -62,6 +66,14 @@ impl<'tunnel> SshTunnelParams<'tunnel> {
     /// Useful if you want use a known port for forwarding.
     pub fn with_local_port(mut self, port: u16) -> Self {
         self.local_socket.set_port(port);
+        self
+    }
+
+    /// Sets the jump port to use.
+    ///
+    /// Useful if you do not want to use the default port for ssh.
+    pub fn with_jump_port(mut self, port: u16) -> Self {
+        self.jump_host.port=port;
         self
     }
 }


### PR DESCRIPTION
I missed the option to use the ssh-tunnel to connect to a device not using the default port (22).
Thus I added the possibility to change the port. I think others may find this useful, because a lot of servers use different ports for ssh to avoid the random traffic at the default port.